### PR TITLE
test: fix Windows test suite (platform-agnostic path assertions)

### DIFF
--- a/tests/integration/sanitize.test.ts
+++ b/tests/integration/sanitize.test.ts
@@ -23,7 +23,10 @@ describe('sanitizeFiles() — integration', () => {
   });
 
   it('renames files with unsafe characters on disk', async () => {
-    const dirty = path.join(tempDir, 'Report<2024>Final.txt');
+    // '<' and '>' cannot exist in Windows filenames at all, so use them only
+    // where the filesystem allows creating the dirty fixture
+    const dirtyName = process.platform === 'win32' ? 'Report (2024) Final.txt' : 'Report<2024>Final.txt';
+    const dirty = path.join(tempDir, dirtyName);
     await fs.writeFile(dirty, 'content');
 
     vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -31,7 +34,7 @@ describe('sanitizeFiles() — integration', () => {
 
     const files = await fs.readdir(tempDir);
     expect(files).toContain('report-2024-final.txt');
-    expect(files).not.toContain('Report<2024>Final.txt');
+    expect(files).not.toContain(dirtyName);
   });
 
   it('does not modify files on disk in dry-run mode', async () => {

--- a/tests/unit/cli/clean-empty.test.ts
+++ b/tests/unit/cli/clean-empty.test.ts
@@ -14,6 +14,7 @@ vi.mock('fs', async () => {
 });
 
 import { promises as fs } from 'fs';
+import path from 'path';
 import { cleanEmptyDirs } from '../../../src/cli/clean-empty.js';
 
 beforeEach(() => {
@@ -69,7 +70,7 @@ describe('cleanEmptyDirs()', () => {
       .mockResolvedValueOnce([]);
     vi.spyOn(console, 'log').mockImplementation(() => {});
     await cleanEmptyDirs('/dir');
-    expect(fs.rmdir).toHaveBeenCalledWith('/dir/empty-sub');
+    expect(fs.rmdir).toHaveBeenCalledWith(path.join('/dir', 'empty-sub'));
   });
 
   it('uses plural "ies" when removing multiple empty directories', async () => {

--- a/tests/unit/cli/flatten.test.ts
+++ b/tests/unit/cli/flatten.test.ts
@@ -16,6 +16,7 @@ vi.mock('fs', async () => {
 vi.mock('../../../src/utils/history.js', () => ({ appendHistory: vi.fn() }));
 
 import { promises as fs } from 'fs';
+import path from 'path';
 import { flattenDirectory } from '../../../src/cli/flatten.js';
 
 beforeEach(() => {
@@ -64,7 +65,7 @@ describe('flattenDirectory()', () => {
     vi.mocked(fs.access).mockRejectedValue(new Error('not found'));
     vi.spyOn(console, 'log').mockImplementation(() => {});
     await flattenDirectory('/dir');
-    expect(fs.rename).toHaveBeenCalledWith('/dir/sub/b.txt', '/dir/b.txt');
+    expect(fs.rename).toHaveBeenCalledWith(path.join('/dir', 'sub', 'b.txt'), path.join('/dir', 'b.txt'));
   });
 
   it('collects files from deeply nested subdirectories', async () => {
@@ -82,7 +83,7 @@ describe('flattenDirectory()', () => {
     vi.mocked(fs.access).mockRejectedValue(new Error('not found'));
     vi.spyOn(console, 'log').mockImplementation(() => {});
     await flattenDirectory('/dir');
-    expect(fs.rename).toHaveBeenCalledWith('/dir/sub/nested/deep.txt', '/dir/deep.txt');
+    expect(fs.rename).toHaveBeenCalledWith(path.join('/dir', 'sub', 'nested', 'deep.txt'), path.join('/dir', 'deep.txt'));
   });
 
   it('resolves naming conflict by appending -1', async () => {
@@ -99,6 +100,6 @@ describe('flattenDirectory()', () => {
       .mockRejectedValueOnce(new Error());    // b-1.txt free
     vi.spyOn(console, 'log').mockImplementation(() => {});
     await flattenDirectory('/dir');
-    expect(fs.rename).toHaveBeenCalledWith('/dir/sub/b.txt', '/dir/b-1.txt');
+    expect(fs.rename).toHaveBeenCalledWith(path.join('/dir', 'sub', 'b.txt'), path.join('/dir', 'b-1.txt'));
   });
 });

--- a/tests/unit/cli/init.test.ts
+++ b/tests/unit/cli/init.test.ts
@@ -19,6 +19,7 @@ vi.mock('os', async () => {
 });
 
 import { promises as fs } from 'fs';
+import path from 'path';
 import inquirer from 'inquirer';
 import { initCommand } from '../../../src/cli/init.js';
 
@@ -51,7 +52,7 @@ describe('initCommand()', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     await initCommand();
     expect(fs.writeFile).toHaveBeenCalledWith(
-      '/home/testuser/.namewise.json',
+      path.join('/home/testuser', '.namewise.json'),
       expect.stringContaining('"provider": "claude"'),
       { encoding: 'utf-8', mode: 0o600 }
     );
@@ -76,7 +77,7 @@ describe('initCommand()', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     await initCommand();
     expect(fs.writeFile).toHaveBeenCalledWith(
-      '/current/dir/.namewise.json',
+      path.join('/current/dir', '.namewise.json'),
       expect.any(String),
       { encoding: 'utf-8', mode: 0o600 }
     );

--- a/tests/unit/utils/config-loader.test.ts
+++ b/tests/unit/utils/config-loader.test.ts
@@ -45,7 +45,7 @@ describe('loadConfig()', () => {
   it('returns project config when only project config exists', async () => {
     const projectConfig: NamiwiseFileConfig = { case: 'snake_case' };
     mockReadFile.mockImplementation(async (fp: any) => {
-      if (String(fp) === path.join('/some/dir', '.namewise.json')) {
+      if (String(fp) === path.join(path.resolve('/some/dir'), '.namewise.json')) {
         return JSON.stringify(projectConfig);
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -59,7 +59,7 @@ describe('loadConfig()', () => {
     const projectConfig: NamiwiseFileConfig = { concurrency: 2 };
     mockReadFile.mockImplementation(async (fp: any) => {
       if (String(fp) === path.join(homeDir, '.namewise.json')) return JSON.stringify(userConfig);
-      if (String(fp) === path.join('/some/dir', '.namewise.json')) return JSON.stringify(projectConfig);
+      if (String(fp) === path.join(path.resolve('/some/dir'), '.namewise.json')) return JSON.stringify(projectConfig);
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     });
     const result = await loadConfig('/some/dir');
@@ -70,7 +70,7 @@ describe('loadConfig()', () => {
   it('warns when the project-level config contains an API key', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockReadFile.mockImplementation(async (fp: any) => {
-      if (String(fp) === path.join('/some/dir', '.namewise.json')) {
+      if (String(fp) === path.join(path.resolve('/some/dir'), '.namewise.json')) {
         return JSON.stringify({ apiKey: 'sk-secret' });
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });

--- a/tests/unit/utils/dedup.test.ts
+++ b/tests/unit/utils/dedup.test.ts
@@ -13,6 +13,7 @@ vi.mock('fs', async () => {
 });
 
 import { createReadStream, promises as fs } from 'fs';
+import path from 'path';
 import { EventEmitter } from 'events';
 import { hashFile, findDuplicates } from '../../../src/utils/dedup.js';
 
@@ -104,7 +105,7 @@ describe('findDuplicates()', () => {
     expect(result.size).toBe(1);
     const [paths] = [...result.values()];
     expect(paths).toHaveLength(2);
-    expect(paths).toContain('/dir/top.txt');
-    expect(paths).toContain('/dir/sub/nested.txt');
+    expect(paths).toContain(path.join('/dir', 'top.txt'));
+    expect(paths).toContain(path.join('/dir', 'sub', 'nested.txt'));
   });
 });

--- a/tests/unit/utils/fs-collect.test.ts
+++ b/tests/unit/utils/fs-collect.test.ts
@@ -13,6 +13,7 @@ vi.mock('fs', async () => {
 });
 
 import { promises as fs } from 'fs';
+import path from 'path';
 import { collectFiles, formatBytes } from '../../../src/utils/fs-collect.js';
 
 beforeEach(() => vi.clearAllMocks());
@@ -24,7 +25,7 @@ describe('collectFiles()', () => {
       { name: 'b.pdf', isDirectory: () => false, isFile: () => true } as any
     ]);
     const result = await collectFiles('/dir');
-    expect(result).toEqual(['/dir/a.txt', '/dir/b.pdf']);
+    expect(result).toEqual([path.join('/dir', 'a.txt'), path.join('/dir', 'b.pdf')]);
   });
 
   it('does not recurse when recursive=false', async () => {
@@ -33,7 +34,7 @@ describe('collectFiles()', () => {
       { name: 'a.txt', isDirectory: () => false, isFile: () => true } as any
     ]);
     const result = await collectFiles('/dir', { recursive: false });
-    expect(result).toEqual(['/dir/a.txt']);
+    expect(result).toEqual([path.join('/dir', 'a.txt')]);
   });
 
   it('recurses into subdirectories when recursive=true', async () => {
@@ -46,7 +47,7 @@ describe('collectFiles()', () => {
         { name: 'b.txt', isDirectory: () => false, isFile: () => true } as any
       ]);
     const result = await collectFiles('/dir', { recursive: true });
-    expect(result).toEqual(['/dir/sub/b.txt', '/dir/a.txt']);
+    expect(result).toEqual([path.join('/dir', 'sub', 'b.txt'), path.join('/dir', 'a.txt')]);
   });
 
   it('respects maxDepth', async () => {
@@ -59,7 +60,7 @@ describe('collectFiles()', () => {
         { name: 'c.txt', isDirectory: () => false, isFile: () => true } as any
       ]);
     const result = await collectFiles('/dir', { recursive: true, maxDepth: 1 });
-    expect(result).toEqual(['/dir/sub/c.txt']);
+    expect(result).toEqual([path.join('/dir', 'sub', 'c.txt')]);
   });
 });
 

--- a/tests/unit/utils/organize.test.ts
+++ b/tests/unit/utils/organize.test.ts
@@ -11,6 +11,7 @@ vi.mock('fs', async () => {
 
 import { collectFiles } from '../../../src/utils/fs-collect.js';
 import { promises as fs } from 'fs';
+import path from 'path';
 import { computeOrganizeMappings } from '../../../src/utils/organize.js';
 
 const refDate = new Date('2024-03-15T00:00:00Z');
@@ -37,7 +38,8 @@ describe('computeOrganizeMappings() by ext', () => {
   });
 
   it('skips files already in the correct subfolder', async () => {
-    vi.mocked(collectFiles).mockResolvedValue(['/dir/pdf/file.pdf']);
+    // Build with path.join so the dirname comparison holds on Windows too
+    vi.mocked(collectFiles).mockResolvedValue([path.join('/dir', 'pdf', 'file.pdf')]);
     const mappings = await computeOrganizeMappings('/dir', 'ext', false);
     expect(mappings).toHaveLength(0);
   });


### PR DESCRIPTION
Tests asserted POSIX path string literals (`/dir/sub/b.txt`) while `path.join`/`path.resolve` produce backslashes and drive letters on Windows, breaking 16 tests across 8 areas on the windows-latest CI matrix. The sanitize integration test also tried to create a file named `Report<2024>Final.txt`, which NTFS forbids.

Product code is unaffected — it consistently uses `path.join`; only test expectations were wrong.

Surfaced by the first PR CI runs in months (Dependabot): `test.yml` only triggers on pull_request, so direct pushes to main never ran the Windows matrix.